### PR TITLE
feat(Dockerfile): add inkscape

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM texlive/texlive
 
 RUN apt-get update
-RUN apt-get install entr
+RUN apt-get install inkscape entr


### PR DESCRIPTION
I could not compile my Beamer presentation that used SVG images, as the localleaf stack derives a bit from the Overleaf stack. As it turns out (from the LaTeX log messages), the missing depency was inkscape, to manage the images.

This commit adds inkscape, so that LaTeX libraries that manipulate images now compile.


Thanks again for this very useful little project.